### PR TITLE
feat: implement Zustand store for managing selected user and repository state with tests

### DIFF
--- a/__tests__/unit/store/AppState.test.ts
+++ b/__tests__/unit/store/AppState.test.ts
@@ -1,0 +1,42 @@
+import { renderHook, act } from "@testing-library/react";
+import { useAppStore } from "@/store/AppState";
+
+describe("useAppStore", () => {
+  beforeEach(() => {
+    useAppStore.setState({ selectedUsername: null, selectedRepo: null });
+  });
+
+  it("should set the selected user correctly", () => {
+    const { setselectedUsername } = useAppStore.getState();
+    setselectedUsername("octocat");
+    const { selectedUsername } = useAppStore.getState();
+    expect(selectedUsername).toBe("octocat");
+  });
+
+  it("should set the selected repository correctly", () => {
+    const { setSelectedRepo } = useAppStore.getState();
+    setSelectedRepo("octocat/hello-world");
+    const { selectedRepo } = useAppStore.getState();
+
+    expect(selectedRepo).toBe("octocat/hello-world");
+  });
+
+  it("should reset the state correctly", () => {
+    const { setselectedUsername, setSelectedRepo, reset } =
+      useAppStore.getState();
+    setselectedUsername("octocat");
+    setSelectedRepo("octocat/hello-world");
+    reset();
+    const { selectedUsername, selectedRepo } = useAppStore.getState();
+    expect(selectedUsername).toBeNull();
+    expect(selectedRepo).toBeNull();
+  });
+
+  it("deve atualizar selectedUsername corretamente em um componente", () => {
+    const { result } = renderHook(() => useAppStore());
+    act(() => {
+      result.current.setselectedUsername("octocat");
+    });
+    expect(result.current.selectedUsername).toBe("octocat");
+  });
+});

--- a/src/store/AppState.ts
+++ b/src/store/AppState.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+interface AppState {
+  selectedUsername: string | null;
+  selectedRepo: string | null;
+  setselectedUsername: (user: string | null) => void;
+  setSelectedRepo: (repo: string | null) => void;
+  reset: () => void;
+}
+
+export const useAppStore = create<AppState>((set) => ({
+  selectedUsername: null,
+  selectedRepo: null,
+  setselectedUsername: (user) => set({ selectedUsername: user }),
+  setSelectedRepo: (repo) => set({ selectedRepo: repo }),
+  reset: () => set({ selectedUsername: null, selectedRepo: null }),
+}));


### PR DESCRIPTION
This pull request introduces a new global state management system using `zustand` to handle application state for selected users and repositories. It also adds unit tests to ensure the correctness of the state management logic.

### State Management Implementation:
* Added a `zustand` store in `src/store/AppState.ts` to manage `selectedUsername` and `selectedRepo` states, along with methods to update or reset these states. (`[src/store/AppState.tsR1-R17](diffhunk://#diff-080c1e9d21ea84cf84b18a421f8a855cee10cde8a6dea104334aa59c8188ddaaR1-R17)`)

### Unit Tests:
* Added unit tests in `__tests__/unit/store/AppState.test.ts` to verify the functionality of the `zustand` store, including setting and resetting `selectedUsername` and `selectedRepo` and ensuring state updates correctly in components. (`[__tests__/unit/store/AppState.test.tsR1-R42](diffhunk://#diff-6cce27e9f55f513f1fd02cedca11ec62f559f936ffaf27128aaeecf6672b9931R1-R42)`)