### PR TITLE
feat: update GitHub service to include pagination and type options in API requests

### DIFF
--- a/__tests__/unit/services/githubService.test.ts
+++ b/__tests__/unit/services/githubService.test.ts
@@ -24,7 +24,7 @@ describe("Github Service - searchRepos", () => {
     expect(repos).toEqual(mockRepos);
     expect(mockedAxiosInstance.get).toHaveBeenCalledTimes(1);
     expect(mockedAxiosInstance.get).toHaveBeenCalledWith(
-      "/search/repositories?q=react"
+      "/search/repositories?q=react&page=1&per_page=30"
     );
   });
 
@@ -69,7 +69,7 @@ describe("Github Service - searchUsers", () => {
     expect(users).toEqual([mockUserProfile]);
     expect(mockedAxiosInstance.get).toHaveBeenCalledTimes(1);
     expect(mockedAxiosInstance.get).toHaveBeenCalledWith(
-      "/search/users?q=octocat"
+      "/search/users?q=octocat&page=1&per_page=30"
     );
   });
 
@@ -113,7 +113,7 @@ describe("Github Service - getUserProfile", () => {
 
     expect(profile).toEqual(mockUserProfile);
     expect(mockedAxiosInstance.get).toHaveBeenCalledTimes(1);
-    expect(mockedAxiosInstance.get).toHaveBeenCalledWith(`/users/${username}`);
+    expect(mockedAxiosInstance.get).toHaveBeenCalledWith(`/users/${username}?page=1&per_page=30`);
   });
 
   it("should handle fetch error", async () => {
@@ -158,7 +158,7 @@ describe("Github Service - getUserStarredRepos", () => {
     expect(repos).toEqual(mockRepos);
     expect(mockedAxiosInstance.get).toHaveBeenCalledTimes(1);
     expect(mockedAxiosInstance.get).toHaveBeenCalledWith(
-      `/users/${username}/starred`
+      `/users/${username}/starred?page=1&per_page=30&type=all`
     );
   });
 
@@ -183,7 +183,7 @@ describe("Github Service - getUserStarredRepos", () => {
     await githubService.getUserStarredRepos(username, options);
 
     expect(mockedAxiosInstance.get).toHaveBeenCalledWith(
-      `/users/${username}/starred?page=${options.page}&per_page=${options.perPage}`
+      `/users/${username}/starred?page=${options.page}&per_page=${options.perPage}&type=all`
     );
   });
 });
@@ -204,7 +204,7 @@ describe("Github Service - getUserRepos", () => {
     expect(repos).toEqual(mockRepos);
     expect(mockedAxiosInstance.get).toHaveBeenCalledTimes(1);
     expect(mockedAxiosInstance.get).toHaveBeenCalledWith(
-      `/users/${username}/repos`
+      `/users/${username}/repos?page=1&per_page=30&type=all`
     );
   });
 
@@ -229,7 +229,7 @@ describe("Github Service - getUserRepos", () => {
     await githubService.getUserRepos(username, options);
 
     expect(mockedAxiosInstance.get).toHaveBeenCalledWith(
-      `/users/${username}/repos?page=${options.page}&per_page=${options.perPage}`
+      `/users/${username}/repos?page=${options.page}&per_page=${options.perPage}&type=all`
     );
   });
 });

--- a/src/services/githubService.ts
+++ b/src/services/githubService.ts
@@ -10,18 +10,28 @@ import {
 import axiosInstance from "./axiosGithubInstance";
 import { normalizeProfiles } from "@/utils/normalizeProfiles";
 
-interface queryOptions {
+interface IQueryOptions {
   page?: number;
   perPage?: number;
+  language?: string;
+}
+
+interface IRepoQueryOptions extends IQueryOptions {
+  type?: "all" | "owner" | "member";
 }
 
 export const githubService = {
   async searchRepos(
     query: string,
-    options?: queryOptions
+    options?: IQueryOptions
   ): Promise<IRepository[]> {
     try {
-      const url = `/search/repositories?q=${query}${options ? `&page=${options?.page}&per_page=${options?.perPage}` : ""}`;
+      const params = new URLSearchParams({
+        ...(query ? { q: query } : {}),
+        page: options?.page?.toString() || "1",
+        per_page: options?.perPage?.toString() || "30",
+      });
+      const url = `/search/repositories${params.toString() ? `?${params.toString()}` : ""}`;
 
       const response = await axiosInstance.get(url);
 
@@ -34,10 +44,15 @@ export const githubService = {
 
   async searchUsers(
     query: string,
-    options?: queryOptions
+    options?: IQueryOptions
   ): Promise<IProfile[]> {
     try {
-      const url = `/search/users?q=${query}${options ? `&page=${options?.page}&per_page=${options?.perPage}` : ""}`;
+      const params = new URLSearchParams({
+        ...(query && { q: query }),
+        page: options?.page?.toString() || "1",
+        per_page: options?.perPage?.toString() || "30",
+      });
+      const url = `/search/users${params.toString() ? `?${params.toString()}` : ""}`;
       const response = await axiosInstance.get(url);
       const rawData: IGithubSearchUserDTO = await response.data;
       const users: IProfile[] = normalizeProfiles(rawData.items);
@@ -49,10 +64,15 @@ export const githubService = {
 
   async getUserProfile(
     username: string,
-    options?: queryOptions
+    options?: IQueryOptions
   ): Promise<IProfile> {
     try {
-      const url = `/users/${username}${options ? `?page=${options?.page}&per_page=${options?.perPage}` : ""}`;
+      const params = new URLSearchParams({
+        page: options?.page?.toString() || "1",
+        per_page: options?.perPage?.toString() || "30",
+      });
+
+      const url = `/users/${username}${params.toString() ? `?${params.toString()}` : ""}`;
       const response = await axiosInstance.get(url);
 
       const userProfile: IGithubUserProfile = await response.data;
@@ -67,10 +87,19 @@ export const githubService = {
 
   async getUserStarredRepos(
     username: string,
-    options?: queryOptions
+    options?: IRepoQueryOptions
   ): Promise<IRepository[]> {
     try {
-      const url = `/users/${username}/starred${options ? `?page=${options?.page}&per_page=${options?.perPage}` : ""}`;
+      const params = new URLSearchParams({
+        ...(options?.language && {
+          q: `language:${options?.language}`,
+        }),
+        page: options?.page?.toString() || "1",
+        per_page: options?.perPage?.toString() || "30",
+        type: options?.type || "all",
+      });
+
+      const url = `/users/${username}/starred${params.toString() ? `?${params.toString()}` : ""}`;
       const response = await axiosInstance.get(url);
       const starredRepos: IRawRepository[] = await response.data;
       const normalizedStarredRepos: IRepository[] =
@@ -84,10 +113,19 @@ export const githubService = {
 
   async getUserRepos(
     username: string,
-    options?: queryOptions
+    options?: IRepoQueryOptions
   ): Promise<IRepository[]> {
     try {
-      const url = `/users/${username}/repos${options ? `?page=${options?.page}&per_page=${options?.perPage}` : ""}`;
+      const params = new URLSearchParams({
+        ...(options?.language && {
+          q: `language:${options?.language}`,
+        }),
+        page: options?.page?.toString() || "1",
+        per_page: options?.perPage?.toString() || "30",
+        type: options?.type || "all",
+      });
+
+      const url = `/users/${username}/repos${params.toString() ? `?${params.toString()}` : ""}`;
       const response = await axiosInstance.get(url);
       const repos: IRawRepository[] = await response.data;
       const normalizedRepos: IRepository[] = normalizeRepos(repos);


### PR DESCRIPTION
This pull request refactors the `githubService` module to improve query parameter handling for various GitHub API endpoints and updates the corresponding unit tests to reflect these changes. The updates include introducing interfaces for query options, standardizing URL parameter construction using `URLSearchParams`, and adding support for new query parameters like `type` and `language`.

### Refactoring of `githubService` module:

* Introduced `IQueryOptions` and `IRepoQueryOptions` interfaces to define optional query parameters for API requests, adding support for `type` and `language` parameters. (`src/services/githubService.ts`, [src/services/githubService.tsL13-R34](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafL13-R34))
* Updated methods (`searchRepos`, `searchUsers`, `getUserProfile`, `getUserStarredRepos`, and `getUserRepos`) to use `URLSearchParams` for cleaner and more dynamic query parameter construction. (`src/services/githubService.ts`, [[1]](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafL13-R34) [[2]](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafL37-R55) [[3]](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafL52-R75) [[4]](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafL70-R102) [[5]](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafL87-R128)

### Unit test updates:

* Adjusted test cases for `searchRepos`, `searchUsers`, `getUserProfile`, `getUserStarredRepos`, and `getUserRepos` to validate the new query parameter structure, including default values for `page`, `per_page`, and `type`. (`__tests__/unit/services/githubService.test.ts`, [[1]](diffhunk://#diff-a73054d447a7ae2ddaed881fa7a5424d0b46bf896d2c8cdb13a78d2d1fe490efL27-R27) [[2]](diffhunk://#diff-a73054d447a7ae2ddaed881fa7a5424d0b46bf896d2c8cdb13a78d2d1fe490efL72-R72) [[3]](diffhunk://#diff-a73054d447a7ae2ddaed881fa7a5424d0b46bf896d2c8cdb13a78d2d1fe490efL116-R116) [[4]](diffhunk://#diff-a73054d447a7ae2ddaed881fa7a5424d0b46bf896d2c8cdb13a78d2d1fe490efL161-R161) [[5]](diffhunk://#diff-a73054d447a7ae2ddaed881fa7a5424d0b46bf896d2c8cdb13a78d2d1fe490efL186-R186) [[6]](diffhunk://#diff-a73054d447a7ae2ddaed881fa7a5424d0b46bf896d2c8cdb13a78d2d1fe490efL207-R207) [[7]](diffhunk://#diff-a73054d447a7ae2ddaed881fa7a5424d0b46bf896d2c8cdb13a78d2d1fe490efL232-R232) 