### PR TITLE
refactor: refactor GitHub service configuration and tests

### DIFF
--- a/__tests__/integration/services/githubService.test.ts
+++ b/__tests__/integration/services/githubService.test.ts
@@ -1,5 +1,7 @@
 import { githubService } from "@/services/githubService";
 
+jest.setTimeout(30000);
+
 describe("Github Service - searchRepos", () => {
   it("should fetch repositories successfully", async () => {
     const repos = await githubService.searchRepos("react");

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  env: {
+    GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+  },
 };
 
 export default nextConfig;

--- a/src/services/axiosGithubInstance.ts
+++ b/src/services/axiosGithubInstance.ts
@@ -2,10 +2,10 @@ import { C } from "@/utils";
 import axios from "axios";
 
 const axiosInstance = axios.create({
-  baseURL: C.GITHUB_API_URL,
+  baseURL: C.githubApiUrl,
   headers: {
     "Content-Type": "application/json",
-    ...(C.GITHUB_API_TOKEN && { Authorization: `token ${C.GITHUB_API_TOKEN}` }),
+    ...(C.githubApiToken && { Authorization: `token ${C.githubApiToken}` }),
   },
 });
 

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,9 +1,9 @@
 interface config {
-  GITHUB_API_URL: string;
-  GITHUB_API_TOKEN: string;
+  githubApiUrl: string;
+  githubApiToken: string;
 }
 
 export const C: config = {
-  GITHUB_API_URL: "https://api.github.com",
-  GITHUB_API_TOKEN: process.env.GITHUB_API_TOKEN as string,
+  githubApiUrl: "https://api.github.com",
+  githubApiToken: process.env.GITHUB_API_TOKEN as string,
 };


### PR DESCRIPTION
This pull request introduces several changes to improve configuration handling, update naming conventions for consistency, and enhance test reliability. The key updates include renaming configuration properties, updating references to these properties, and increasing the timeout for integration tests.

### Configuration Updates:
* [`src/utils/config.ts`](diffhunk://#diff-285dea82a685fcd275e82141070c164a79a6650d46573cfd6303381afc47b28bL2-R8): Renamed `GITHUB_API_URL` to `githubApiUrl` and `GITHUB_API_TOKEN` to `githubApiToken` for consistent naming conventions. Updated the configuration object accordingly.
* [`src/services/axiosGithubInstance.ts`](diffhunk://#diff-76fedf645b535d8969c04f4bdcbb1a128011b923d50f933cf9edf8deb2f9212cL5-R8): Updated references to the renamed configuration properties (`C.GITHUB_API_URL` -> `C.githubApiUrl`, `C.GITHUB_API_TOKEN` -> `C.githubApiToken`).
* [`next.config.ts`](diffhunk://#diff-e3f38f2f0e7ba92f0dd56c086ec5de704229d58d5371e8cc57e43961757d8c7bL4-R6): Added `GITHUB_TOKEN` to the environment variables configuration to allow access to the GitHub token via `process.env`.

### Test Enhancements:
* [`__tests__/integration/services/githubService.test.ts`](diffhunk://#diff-8ca9c5279588102277a96eff2578bd8bf24f9c3f3b128239f52d4a65521bc4f4R3-R4): Increased the Jest timeout to 30 seconds to prevent tests from failing due to timeout issues during integration tests.