### PR TITLE
refactor: simplify imports by consolidating component paths

### DIFF
--- a/src/app/500.tsx
+++ b/src/app/500.tsx
@@ -1,4 +1,4 @@
-import { ErrorFrame } from "@/components/Frames/ErrorFrame";
+import { ErrorFrame } from "@/components";
 
 const custom500 = () => {
   return (

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ErrorFrame } from "@/components/Frames/ErrorFrame";
+import { ErrorFrame } from "@/components";
 import { C } from "@/utils";
 
 export default function GlobalError({ error }: { error: Error }) {

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,4 +1,4 @@
-import { ErrorFrame } from "@/components/Frames/ErrorFrame";
+import { ErrorFrame } from "@/components";
 
 const NotFoundPage = () => {
   return (

--- a/src/app/profile/500.tsx
+++ b/src/app/profile/500.tsx
@@ -1,4 +1,4 @@
-import { ErrorFrame } from "@/components/Frames/ErrorFrame";
+import { ErrorFrame } from "@/components";
 
 const custom500 = () => {
   return (

--- a/src/app/profile/[username]/[repoName]/500.tsx
+++ b/src/app/profile/[username]/[repoName]/500.tsx
@@ -1,4 +1,4 @@
-import { ErrorFrame } from "@/components/Frames/ErrorFrame";
+import { ErrorFrame } from "@/components";
 
 const custom500 = () => {
   return (

--- a/src/app/profile/[username]/[repoName]/page.tsx
+++ b/src/app/profile/[username]/[repoName]/page.tsx
@@ -1,4 +1,4 @@
-import { RepositoryFrame } from "@/components/Frames/RepositoryFrame";
+import { RepositoryFrame } from "@/components";
 import { githubService } from "@/services/githubService";
 
 interface ProfilePageProps {

--- a/src/components/Frames/index.ts
+++ b/src/components/Frames/index.ts
@@ -1,1 +1,3 @@
 export * from "./ProfileFrame"
+export * from "./ErrorFrame"
+export * from "./RepositoryFrame"

--- a/src/components/Sections/ProfileRepoTabsSection.tsx
+++ b/src/components/Sections/ProfileRepoTabsSection.tsx
@@ -1,7 +1,6 @@
 import { IPaginationReturn, IProfile, IRepository } from "@/types";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@radix-ui/react-tabs";
-import { IconsStar, Bookmark } from "@/components";
-import { RepositorySearchSection } from "@/components/Repository/RepositorySearchSection";
+import { IconsStar, Bookmark, RepositorySearchSection } from "@/components";
 
 interface ProfileRepoTabsSectionProps {
   profile: IProfile;


### PR DESCRIPTION
This pull request refactors imports across multiple files to simplify and standardize component references by utilizing the `index.ts` file in the `Frames` directory. It also updates the `index.ts` file to export additional components, enabling this streamlined import structure.

### Refactoring imports for consistency:
* Updated imports in `src/app/500.tsx`, `src/app/error.tsx`, `src/app/not-found.tsx`, `src/app/profile/500.tsx`, and `src/app/profile/[username]/[repoName]/500.tsx` to import `ErrorFrame` directly from `"@/components"` instead of `"@/components/Frames/ErrorFrame"`. [[1]](diffhunk://#diff-83f5b120e48fee5bc68afd8f8ccb50c2142bc3256d7d5f7e76fb245170981d6fL1-R1) [[2]](diffhunk://#diff-782fd804d3006001aeba1a91e51d6491b6d49dbaf5b7c3fee69aca89738c830bL3-R3) [[3]](diffhunk://#diff-f656f59519a290bb5f099f48ce59a37b32c20b0276f0e83e884051f0be43db43L1-R1)
* Updated the import in `src/app/profile/[username]/[repoName]/page.tsx` to import `RepositoryFrame` directly from `"@/components"` instead of `"@/components/Frames/RepositoryFrame"`. ([src/app/profile/[username]/[repoName]/page.tsxL1-R1](diffhunk://#diff-e19755f47fcfc6b7585a65281b5d37bf10463e7be8a18137c6e8f0337fef3b66L1-R1))
* Updated the import in `src/components/Sections/ProfileRepoTabsSection.tsx` to include `RepositorySearchSection` directly from `"@/components"`.

### Enhancing `index.ts` for centralized exports:
* Added `ErrorFrame` and `RepositoryFrame` exports to `src/components/Frames/index.ts`, enabling centralized and simplified imports for these components.