### PR TITLE
refactor: update lodash debounce import for better perfomance

### DIFF
--- a/__tests__/unit/hooks/useRepoFilters.test.ts
+++ b/__tests__/unit/hooks/useRepoFilters.test.ts
@@ -6,9 +6,7 @@ import { IPaginationReturn, IRepository } from "@/types";
 import { mockRepos } from "@/tests/mocks";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 
-jest.mock("lodash", () => ({
-  debounce: jest.fn((fn) => fn),
-}));
+jest.mock('lodash/debounce', () => jest.fn((fn) => fn));
 
 jest.mock("@/utils/filterRepos", () => ({
   filterAndSortRepos: jest.fn(),

--- a/src/hooks/useRepoFilters.ts
+++ b/src/hooks/useRepoFilters.ts
@@ -1,5 +1,5 @@
 import { useState, useMemo, useEffect, useCallback } from "react";
-import { debounce } from "lodash";
+import debounce from "lodash/debounce";
 import { filterAndSortRepos } from "@/utils/filterRepos";
 import { IPaginationReturn, IRepository } from "@/types";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";


### PR DESCRIPTION
This pull request refactors the way the `lodash` library is imported and mocked to improve module resolution and tree-shaking. The changes focus on switching from importing the entire library to importing only the `debounce` function directly.

### Refactoring of `lodash` imports:

* [`__tests__/unit/hooks/useRepoFilters.test.ts`](diffhunk://#diff-37acd076b2cbb008c4a16c5e51a424eaf3efe55c5cf5ab3cd6e0a214e6a8cf4dL9-R9): Updated the `jest.mock` statement to mock only the `lodash/debounce` module instead of the entire `lodash` library.
* [`src/hooks/useRepoFilters.ts`](diffhunk://#diff-99b3cd13bc83632804855327a4e8605e45610e734c9749f57356a4d3e4ae9a05L2-R2): Changed the import statement to import `debounce` directly from `lodash/debounce` rather than from the entire `lodash` library.