### PR TITLE
Feat/loading router

### DIFF
--- a/src/app/loading.tsx
+++ b/src/app/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingFrame } from "@/components";
+
+export default function ProfilePageSkeleton() {
+  return <LoadingFrame />;
+}

--- a/src/app/profile/[username]/loading.tsx
+++ b/src/app/profile/[username]/loading.tsx
@@ -1,0 +1,5 @@
+import { LoadingFrame } from "@/components";
+
+export default function ProfilePageSkeleton() {
+  return <LoadingFrame />;
+}

--- a/src/components/Frames/LoadingFrame.tsx
+++ b/src/components/Frames/LoadingFrame.tsx
@@ -1,0 +1,30 @@
+export const LoadingFrame = () => {
+  return (
+    <main className="flex flex-col justify-center md:items-start items-center mx-auto px-4 py-8 md:grid grid-cols-3 gap-4 w-full lg:max-w-5xl animate-pulse">
+      <section className="w-full max-w-xs space-y-4">
+        <div className="h-24 w-24 rounded-full bg-gray-300 mx-auto md:mx-0" />
+        <div className="h-4 w-3/4 bg-gray-300 rounded" />
+        <div className="h-4 w-1/2 bg-gray-300 rounded" />
+        <div className="h-4 w-full bg-gray-300 rounded" />
+      </section>
+
+      <section className="col-span-2 w-full max-w-3xl space-y-4">
+        <div className="flex gap-4">
+          <div className="h-8 w-24 bg-gray-300 rounded" />
+          <div className="h-8 w-24 bg-gray-200 rounded" />
+        </div>
+
+        {[...Array(3)].map((_, idx) => (
+          <div
+            key={idx}
+            className="p-4 bg-gray-200 rounded shadow-sm space-y-2"
+          >
+            <div className="h-4 w-3/4 bg-gray-300 rounded" />
+            <div className="h-3 w-2/4 bg-gray-300 rounded" />
+            <div className="h-3 w-full bg-gray-200 rounded" />
+          </div>
+        ))}
+      </section>
+    </main>
+  );
+};

--- a/src/components/Frames/RepositoryFrame.tsx
+++ b/src/components/Frames/RepositoryFrame.tsx
@@ -5,6 +5,7 @@ import {
   RepositoryDetailsSection,
   RepositoryStatsSection,
 } from "@/components";
+import { AnimatedCardWrapper } from "../Animation";
 
 interface RepositoryFrameProps {
   repository: IRepository;
@@ -26,13 +27,13 @@ export const RepositoryFrame: React.FC<RepositoryFrameProps> = ({
 
       <section className="space-y-4 w-full max-w-3xl">
         {issues.items.map((issue: IIssue, index: number) => (
-          <div key={index} className="p-4 rounded-md bg-white">
+          <AnimatedCardWrapper key={index} className="p-4 rounded-md bg-white">
             <div className="font-bold text-gray-800">{issue.title}</div>
             <div className="text-gray-400 font-semibold">
               {issue.createdAt && issue.createdAt.toLocaleString()} by{" "}
               {issue.user.login}
             </div>
-          </div>
+          </AnimatedCardWrapper>
         ))}
       </section>
     </main>

--- a/src/components/Frames/index.ts
+++ b/src/components/Frames/index.ts
@@ -1,3 +1,4 @@
-export * from "./ProfileFrame"
-export * from "./ErrorFrame"
-export * from "./RepositoryFrame"
+export * from "./ProfileFrame";
+export * from "./ErrorFrame";
+export * from "./RepositoryFrame";
+export * from "./LoadingFrame";

--- a/src/components/Repository/RepositoryList.tsx
+++ b/src/components/Repository/RepositoryList.tsx
@@ -11,7 +11,6 @@ interface RepositoryListProps {
 
 const RepositoryList: React.FC<RepositoryListProps> = ({
   filteredRepos,
-  username,
 }) => {
   return (
     <div className="grid gap-4 mt-4">
@@ -19,7 +18,7 @@ const RepositoryList: React.FC<RepositoryListProps> = ({
         <AnimatedCardWrapper key={repo.id} className="flex flex-col gap-4">
           <Link
             key={repo.id}
-            href={`/profile/${username}/${repo.name}`}
+            href={`/profile/${repo.owner.login}/${repo.name}`}
             className="cursor-pointer"
           >
             <RepositoryCard repository={repo} />

--- a/src/services/githubService.ts
+++ b/src/services/githubService.ts
@@ -72,7 +72,7 @@ export const githubService = {
 
       return normalizeProfile;
     } catch (error) {
-      console.error(error);
+      console.log("Github Service - userProfile error", error);
       throw error;
     }
   },
@@ -99,6 +99,7 @@ export const githubService = {
 
       return normalizedStarredRepos;
     } catch (error) {
+      console.log("Github Service - getUserStarredRepos error", error);
       throw error;
     }
   },
@@ -111,6 +112,7 @@ export const githubService = {
       const normalizedRepo: IRepository = normalizeRepos([repo])[0];
       return normalizedRepo;
     } catch (error) {
+      console.log("Github Service - getRepo error", error);
       throw error;
     }
   },
@@ -135,6 +137,7 @@ export const githubService = {
       const normalizedIssues: IIssue[] = normalizeIssue(issues);
       return normalizedIssues;
     } catch (error) {
+      console.log("Github Service - getIssues error", error);
       throw error;
     }
   },
@@ -166,38 +169,44 @@ export const githubService = {
   async getAllUserRepos(
     username: string
   ): Promise<IPaginationReturn<IRepository>> {
-    const allRepos: IRepository[] = [];
-    let page = 1;
-    const perPage = 30;
+    try {
+      const maxPage = 4;
+      const allRepos: IRepository[] = [];
+      let page = 1;
+      const perPage = 30;
 
-    while (true) {
-      const paginatedRepos = await this.getUserRepos(username, {
-        page,
-        perPage,
-      });
+      while (true) {
+        const paginatedRepos = await this.getUserRepos(username, {
+          page,
+          perPage,
+        });
 
-      allRepos.push(...paginatedRepos);
+        allRepos.push(...paginatedRepos);
 
-      if (paginatedRepos.length < perPage) break;
+        if (paginatedRepos.length < perPage || page === maxPage) break;
+        page++;
+      }
 
-      page++;
+      const paginatedReturn = allRepos.reduce(
+        (acc: IPaginationReturn<IRepository>, repo: IRepository) => {
+          acc.items.push(repo);
+          acc.totalCount += 1;
+          return acc;
+        },
+        { items: [], totalCount: 0 }
+      );
+
+      return paginatedReturn;
+    } catch (error) {
+      console.error("Github Service - getAllUserRepos error", error);
+      throw error;
     }
-
-    const paginatedReturn = allRepos.reduce(
-      (acc: IPaginationReturn<IRepository>, repo: IRepository) => {
-        acc.items.push(repo);
-        acc.totalCount += 1;
-        return acc;
-      },
-      { items: [], totalCount: 0 }
-    );
-
-    return paginatedReturn;
   },
 
   async getAllUserStarredRepos(
     username: string
   ): Promise<IPaginationReturn<IRepository>> {
+    const maxPage = 4;
     const allStarredRepos: IRepository[] = [];
     let page = 1;
     const perPage = 30;
@@ -207,7 +216,7 @@ export const githubService = {
         perPage,
       });
       allStarredRepos.push(...paginatedStarredRepos);
-      if (paginatedStarredRepos.length < perPage) break;
+      if (paginatedStarredRepos.length < perPage || page === maxPage) break;
       page++;
     }
 
@@ -227,6 +236,7 @@ export const githubService = {
     username: string,
     repoName: string
   ): Promise<IPaginationReturn<IIssue>> {
+    const maxPage = 4;
     const allIssues: IIssue[] = [];
     let page = 1;
     const perPage = 30;
@@ -239,7 +249,7 @@ export const githubService = {
 
       allIssues.push(...paginatedIssues);
 
-      if (paginatedIssues.length < perPage) break;
+      if (paginatedIssues.length < perPage || page === maxPage) break;
 
       page++;
     }


### PR DESCRIPTION
This pull request introduces a new `LoadingFrame` component for skeleton loading states, integrates it into the application, and makes several improvements to error handling, pagination logic, and UI animations. The most important changes are grouped below by theme.

### Skeleton Loading State
* Added a new `LoadingFrame` component in `src/components/Frames/LoadingFrame.tsx` to display a skeleton UI during loading.
* Integrated the `LoadingFrame` component into the `ProfilePageSkeleton` in `src/app/loading.tsx` and `src/app/profile/[username]/loading.tsx`.
* Exported `LoadingFrame` from `src/components/Frames/index.ts`.

### UI Enhancements
* Updated `RepositoryFrame` to wrap issues in an `AnimatedCardWrapper` for smoother animations in `src/components/Frames/RepositoryFrame.tsx`. [[1]](diffhunk://#diff-3dcc9807f55cc1a753b933dcadc73c4273659f266633222bc29db4c23a78849eR8) [[2]](diffhunk://#diff-3dcc9807f55cc1a753b933dcadc73c4273659f266633222bc29db4c23a78849eL29-R36)
* Modified `RepositoryList` to use the repository owner's username in the `href` instead of a static `username` property in `src/components/Repository/RepositoryList.tsx`.

### Error Handling Improvements
* Replaced `console.error` with more descriptive `console.log` messages in `githubService` methods to improve debugging. [[1]](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafL75-R75) [[2]](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafR102) [[3]](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafR115) [[4]](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafR140)

### Pagination Logic Updates
* Introduced a `maxPage` limit of 4 to prevent excessive API calls in `getAllUserRepos`, `getAllUserStarredRepos`, and `getIssues` methods in `githubService`. [[1]](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafR172-R173) [[2]](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafL181-R186) [[3]](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafR200-R209) [[4]](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafL210-R219) [[5]](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafR239) [[6]](diffhunk://#diff-94361d0a3c07b8d748b508f26b91ff8aaf13fadd5248b7f5a22a233e993cfbafL242-R252)