### PR TITLE
fix: first card to appear are invisible until scroll

### DIFF
--- a/src/components/Animation/AnimatedCardWrapper.tsx
+++ b/src/components/Animation/AnimatedCardWrapper.tsx
@@ -1,21 +1,25 @@
 "use client";
 
-import { motion } from "framer-motion";
-import React from "react";
+import { motion, useInView } from "framer-motion";
+import React, { useRef } from "react";
 
 interface AnimatedCardWrapperProps
   extends React.ComponentPropsWithoutRef<typeof motion.div> {
   children: React.ReactNode;
 }
+
 export const AnimatedCardWrapper = ({
   children,
   ...props
 }: AnimatedCardWrapperProps) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const isInView = useInView(ref, { once: true, amount: 0.2 });
+
   return (
     <motion.div
+      ref={ref}
       initial={{ opacity: 0, y: 20 }}
-      whileInView={{ opacity: 1, y: 0 }}
-      viewport={{ once: true, amount: 0.2 }}
+      animate={isInView ? { opacity: 1, y: 0 } : {}}
       transition={{ duration: 0.5, ease: "easeOut" }}
       {...props}
     >


### PR DESCRIPTION
This pull request refactors the `AnimatedCardWrapper` component to improve how it handles animation triggers by replacing the `whileInView` and `viewport` properties with the `useInView` hook for better control and flexibility.

### Refactor to improve animation handling:

* [`src/components/Animation/AnimatedCardWrapper.tsx`](diffhunk://#diff-c76990f7cda2b2e98d3301c92601d50eae6d410181ebd5845bf39e2169b2e0aaL3-R22): Replaced the `whileInView` and `viewport` properties with the `useInView` hook and a `ref` to manually track when the card is in view. This allows for more explicit control over the animation state.