### PR TITLE
feat: changing all fonts to roboto

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,13 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Roboto } from "next/font/google";
 import "./globals.css";
 import { Providers } from "./providers";
 import { Header } from "@/components";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const roboto = Roboto({
+  variable: "--font-roboto",
   subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  weight: ["400", "500", "700"], // ajuste conforme necessário
 });
 
 export const metadata: Metadata = {
@@ -26,9 +22,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="pt-BR">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} bg-amber-50 antialiased`}
-      >
+      <body className={`${roboto.variable} bg-amber-50 antialiased`}>
         <Header />
         <Providers>{children}</Providers>
       </body>


### PR DESCRIPTION
This pull request updates the font usage in the `src/app/layout.tsx` file, replacing the previous fonts with a new one to simplify and standardize the typography.

### Font Changes:
* Replaced the `Geist` and `Geist_Mono` fonts with the `Roboto` font, including specifying weights (400, 500, 700) for better flexibility. (`[src/app/layout.tsxL2-R10](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L2-R10)`)
* Updated the `className` in the `<body>` tag to use the `Roboto` font variable instead of the previous `Geist` and `Geist_Mono` variables. (`[src/app/layout.tsxL29-R25](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L29-R25)`)